### PR TITLE
Fix HTML footer output

### DIFF
--- a/app/services/html.cpp
+++ b/app/services/html.cpp
@@ -162,12 +162,12 @@ class Html {
 			return compiled_element_tags;
 		}
 
-		std::string generateFooter() {
-						return "\n</body>\n<footer>\n" + footer_title + "\n</footer>\n"
-													+ generateScripts() +
-													"</body>\n"
-													"</html>\n";
-		}
+                std::string generateFooter() {
+                        return "\n<footer>\n" + footer_title + "\n</footer>\n"
+                                       + generateScripts()
+                                       + "</body>\n"
+                                       + "</html>\n";
+                }
 
 		std::string generateStyles() {
 			std::string compiled_styles;


### PR DESCRIPTION
## Summary
- remove duplicate closing `</body>` tag in `Html` footer

## Testing
- `g++ application.cpp -std=c++11 -pthread -o cpp-on-rails`

------
https://chatgpt.com/codex/tasks/task_e_6843ea8a743c8324b5719018c1f4e201