### PR TITLE
Fix missing Windows headers

### DIFF
--- a/config/routes.cpp
+++ b/config/routes.cpp
@@ -1,5 +1,9 @@
 #include "./../lib/httplib.h"
 #include "./../app/controllers/ApplicationController.h"
+#ifdef _WIN32
+#include <windows.h>
+#include <shellapi.h>
+#endif
 
 int chosenPort = 8080;
 


### PR DESCRIPTION
## Summary
- include `<windows.h>` and `<shellapi.h>` in `config/routes.cpp` for Windows builds

## Testing
- `make`
- `g++ -std=c++17 tests/test_home_view.cpp -o tests/run_tests && ./tests/run_tests`

------
https://chatgpt.com/codex/tasks/task_e_6843f5b326b08324bd3612d8ab4854ec