### PR TITLE
Add basic page designs

### DIFF
--- a/app/views/pages/about_view.cpp
+++ b/app/views/pages/about_view.cpp
@@ -1,7 +1,17 @@
 class AboutView : public Html {
-	public:
-		void buildContent() override {
-			addStyle("h1#about", "padding-left", "15px");
-			addElementTag("<h1 id='about'>About Page</h1>");
-		}
+        public:
+                void buildContent() override {
+                        addRawStyle(R"(
+                                .container { max-width: 800px; margin: 50px auto; padding: 20px; background-color: #fff; box-shadow: 0 2px 4px rgba(0,0,0,0.1); }
+                                h1#about { margin-bottom: 10px; text-align: center; }
+                                p { line-height: 1.6; }
+                        )");
+
+                        addElementTag(R"(
+                                <div class='container'>
+                                        <h1 id='about'>About Us</h1>
+                                        <p>This sample project demonstrates a basic C++ web framework.</p>
+                                </div>
+                        )");
+                }
 };

--- a/app/views/pages/contact_view.cpp
+++ b/app/views/pages/contact_view.cpp
@@ -1,7 +1,24 @@
 class ContactView : public Html {
-	public:
-		void buildContent() override {
-			addStyle("h1#contact", "padding-left", "15px");
-			addElementTag("<h1 id='contact'>Contact Page</h1>");
-		}
+        public:
+                void buildContent() override {
+                        addRawStyle(R"(
+                                .container { max-width: 800px; margin: 50px auto; padding: 20px; background-color: #fff; box-shadow: 0 2px 4px rgba(0,0,0,0.1); }
+                                h1#contact { margin-bottom: 10px; text-align: center; }
+                                form { display: flex; flex-direction: column; gap: 10px; }
+                                label { font-weight: bold; }
+                                input, textarea { padding: 8px; }
+                        )");
+
+                        addElementTag(R"(
+                                <div class='container'>
+                                        <h1 id='contact'>Contact Us</h1>
+                                        <form>
+                                                <label>Name</label>
+                                                <input type='text' placeholder='Your Name'>
+                                                <label>Message</label>
+                                                <textarea rows='4' placeholder='Your Message'></textarea>
+                                        </form>
+                                </div>
+                        )");
+                }
 };

--- a/app/views/pages/home_view.cpp
+++ b/app/views/pages/home_view.cpp
@@ -1,7 +1,17 @@
 class HomeView : public Html {
-	public:
-		void buildContent() override {
-			addStyle("h1#home", "padding-left", "15px");
-			addElementTag("<h1 id='home'>Home Page</h1>");
-		}
+        public:
+                void buildContent() override {
+                        addRawStyle(R"(
+                                .container { max-width: 800px; margin: 50px auto; padding: 20px; text-align: center; background-color: #fff; box-shadow: 0 2px 4px rgba(0,0,0,0.1); }
+                                h1#home { margin-bottom: 10px; }
+                                p { line-height: 1.6; }
+                        )");
+
+                        addElementTag(R"(
+                                <div class='container'>
+                                        <h1 id='home'>Welcome to C++ on Rails</h1>
+                                        <p>Explore the sample application built with C++.</p>
+                                </div>
+                        )");
+                }
 };

--- a/app/views/pages/services_view.cpp
+++ b/app/views/pages/services_view.cpp
@@ -1,7 +1,22 @@
 class ServicesView : public Html {
-	public:
-		void buildContent() override {
-			addStyle("h1#services", "padding-left", "15px");
-			addElementTag("<h1 id='services'>Services Page</h1>");
-		}
+        public:
+                void buildContent() override {
+                        addRawStyle(R"(
+                                .container { max-width: 800px; margin: 50px auto; padding: 20px; background-color: #fff; box-shadow: 0 2px 4px rgba(0,0,0,0.1); }
+                                h1#services { margin-bottom: 10px; text-align: center; }
+                                ul { list-style-type: disc; margin-left: 20px; }
+                                li { margin-bottom: 5px; }
+                        )");
+
+                        addElementTag(R"(
+                                <div class='container'>
+                                        <h1 id='services'>Our Services</h1>
+                                        <ul>
+                                                <li>Web application development</li>
+                                                <li>Consulting</li>
+                                                <li>Support & maintenance</li>
+                                        </ul>
+                                </div>
+                        )");
+                }
 };


### PR DESCRIPTION
## Summary
- implement sample UI layouts for the Home, About, Services and Contact pages

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6843f987431883249005cc7b2d02b357