### PR TITLE
Add static asset support

### DIFF
--- a/app/assets/app.js
+++ b/app/assets/app.js
@@ -1,0 +1,1 @@
+console.log('Global script loaded.');

--- a/app/assets/style.css
+++ b/app/assets/style.css
@@ -1,0 +1,2 @@
+/* Global stylesheet */
+body { margin: 0; }

--- a/app/services/html.cpp
+++ b/app/services/html.cpp
@@ -14,15 +14,19 @@ class Html {
 	std::vector<std::string> scripts;
         std::vector<std::string> element_tags;
         std::string template_path;
+        std::string global_stylesheet;
+        std::string global_script;
 
 	public:
-		Html(){
-			setSiteTitle("C++ on Rails");
-			setFooterTitle("@ " + getCurrentYear() + " C++ on Rails.");
-			setDefaultStyles();
-			setDefaultScripts();
-			setDefaultElementTags();
-		}
+                Html(){
+                        setSiteTitle("C++ on Rails");
+                        setFooterTitle("@ " + getCurrentYear() + " C++ on Rails.");
+                        setDefaultStyles();
+                        setDefaultScripts();
+                        setDefaultElementTags();
+                        setGlobalStylesheet("/assets/style.css");
+                        setGlobalScript("/assets/app.js");
+                }
 
 		virtual void buildContent(){}
 
@@ -44,6 +48,14 @@ class Html {
 
                 void setTemplatePath(std::string path){
                         template_path = path;
+                }
+
+                void setGlobalStylesheet(std::string path){
+                        global_stylesheet = path;
+                }
+
+                void setGlobalScript(std::string path){
+                        global_script = path;
                 }
 
 		void setDefaultStyles(){
@@ -180,9 +192,9 @@ class Html {
                                        + "</body></html>\n";
                 }
 
-		std::string generateStyles() {
-			std::string compiled_styles;
-			std::unordered_map<std::string, std::vector<KeyValuePair>> groupedStyles;
+                std::string generateStyles() {
+                        std::string compiled_styles;
+                        std::unordered_map<std::string, std::vector<KeyValuePair>> groupedStyles;
 
 			for (const auto& style : styles)
 					groupedStyles[style.element].push_back(style);
@@ -198,20 +210,32 @@ class Html {
 				for(const auto& raw_style : raw_styles)
 					compiled_styles += raw_style;
 
-			removeExtraSpaces(compiled_styles);
+                        removeExtraSpaces(compiled_styles);
 
-			return "<style type='text/css'>" + compiled_styles + "</style>\n";
-		}
+                        std::string result;
+                        if(!global_stylesheet.empty())
+                                result += "<link rel='stylesheet' href='" + global_stylesheet + "'>\n";
 
-		std::string generateScripts() {
-			std::string compiled_scripts;
-			for(const auto& script : scripts)
-				compiled_scripts += script;
+                        result += "<style type='text/css'>" + compiled_styles + "</style>\n";
 
-			removeExtraSpaces(compiled_scripts);
+                        return result;
+                }
 
-			return "<script>" + compiled_scripts + "</script>\n";
-		}
+                std::string generateScripts() {
+                        std::string compiled_scripts;
+                        for(const auto& script : scripts)
+                                compiled_scripts += script;
+
+                        removeExtraSpaces(compiled_scripts);
+
+                        std::string result;
+                        if(!global_script.empty())
+                                result += "<script src='" + global_script + "'></script>\n";
+
+                        result += "<script>" + compiled_scripts + "</script>\n";
+
+                        return result;
+                }
 
                 std::string buildHtmlPage(){
                         if(template_path.empty())

--- a/config/routes.cpp
+++ b/config/routes.cpp
@@ -1,5 +1,7 @@
 #include "./../lib/httplib.h"
 #include "./../app/controllers/ApplicationController.h"
+#include <fstream>
+#include <sstream>
 #ifdef _WIN32
 #include <windows.h>
 #include <shellapi.h>
@@ -25,10 +27,30 @@ void runServer(){
 			res.set_content(controller.services(), "text/html");
 	});
 
-	svr.Get("/contact", [](const httplib::Request& req, httplib::Response& res) {
-			PagesController controller;
-			res.set_content(controller.contact(), "text/html");
-	});
+        svr.Get("/contact", [](const httplib::Request& req, httplib::Response& res) {
+                        PagesController controller;
+                        res.set_content(controller.contact(), "text/html");
+        });
+
+        svr.Get("/assets/style.css", [](const httplib::Request& req, httplib::Response& res) {
+                        std::ifstream file("app/assets/style.css");
+                        if(file){
+                                std::ostringstream ss; ss << file.rdbuf();
+                                res.set_content(ss.str(), "text/css");
+                        } else {
+                                res.status = 404;
+                        }
+        });
+
+        svr.Get("/assets/app.js", [](const httplib::Request& req, httplib::Response& res) {
+                        std::ifstream file("app/assets/app.js");
+                        if(file){
+                                std::ostringstream ss; ss << file.rdbuf();
+                                res.set_content(ss.str(), "application/javascript");
+                        } else {
+                                res.status = 404;
+                        }
+        });
 
 	svr.set_error_handler([](const httplib::Request& req, httplib::Response& res) {
 		res.status = 404; // Set HTTP status code to 404


### PR DESCRIPTION
## Summary
- add global asset defaults in `app/assets`
- extend `Html` with global asset handling
- inject global style/script tags when configured
- serve `style.css` and `app.js` through new routes

## Testing
- `make`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68442d53ae38832487db2ae53191a46e