### PR TITLE
Run clean automatically when building

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ BIN = cpp-on-rails
 TEST_BIN = tests/run_tests
 TEST_SRC = tests/test_home_view.cpp
 
-all: $(BIN)
+all: clean $(BIN)
 
 test: $(TEST_BIN)
 	./$(TEST_BIN)

--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ C++ on Rails is not affiliated with or endorsed by the creators of Ruby on Rails
 
 ## How to use
 1. Clone the repo
-2. Run `make` to build the executable (requires a C++17 compiler).
-3. Run `make clean` to remove the compiled binary and force a rebuild using the `clean` target.
+2. Run `make` to build the executable. This automatically performs `make clean` before compiling.
+3. `make` automatically cleans before compiling, but you can run `make clean` separately to just remove the compiled binary.
 4. Execute `./cpp-on-rails` to start the sample server.
 
 ## Running tests


### PR DESCRIPTION
## Summary
- automatically run the `clean` target before building
- document that `make` now cleans before compiling

## Testing
- `make test`
- `make`


------
https://chatgpt.com/codex/tasks/task_e_684432e341d483249df0e1ea5bcdce76