### PR TITLE
Add dev/prod builds and disable auto browser

### DIFF
--- a/Application.h
+++ b/Application.h
@@ -22,8 +22,10 @@ class Application {
 			// Wait for the server to start (optional)
 			std::this_thread::sleep_for(std::chrono::seconds(1));
 
-			// Open the browser and navigate to the URL
-			openBrowser("http://localhost:" + std::to_string(chosenPort));
+                        // Optionally open the browser in development builds
+#ifdef OPEN_BROWSER
+                        openBrowser("http://localhost:" + std::to_string(chosenPort));
+#endif
 
 			// Join the server thread to wait for it to finish (optional)
 			serverThread.join();

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,12 @@
 CXX = g++
 CXXFLAGS = -std=c++17 -pthread
 SRC = application.cpp
-BIN = cpp-on-rails
+DEV_BIN = cpp-on-rails-dev
+PROD_BIN = cpp-on-rails-prod
 TEST_BIN = tests/run_tests
 TEST_SRC = tests/test_home_view.cpp
 
-all: clean $(BIN)
+all: clean $(DEV_BIN) $(PROD_BIN)
 
 test: $(TEST_BIN)
 	./$(TEST_BIN)
@@ -13,10 +14,13 @@ test: $(TEST_BIN)
 $(TEST_BIN): $(TEST_SRC)
 	$(CXX) $(CXXFLAGS) $^ -o $@
 
-$(BIN): $(SRC)
-	$(CXX) $(CXXFLAGS) $(SRC) -o $(BIN)
+$(DEV_BIN): $(SRC)
+	$(CXX) $(CXXFLAGS) -DDEVELOPMENT $(SRC) -o $(DEV_BIN)
+
+$(PROD_BIN): $(SRC)
+	$(CXX) $(CXXFLAGS) -DPRODUCTION $(SRC) -o $(PROD_BIN)
 
 clean:
-	rm -f $(BIN)
+	rm -f $(DEV_BIN) $(PROD_BIN) $(TEST_BIN)
 
 .PHONY: all clean test

--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ C++ on Rails is not affiliated with or endorsed by the creators of Ruby on Rails
 
 ## How to use
 1. Clone the repo
-2. Run `make` to build the executable. This automatically performs `make clean` before compiling.
-3. `make` automatically cleans before compiling, but you can run `make clean` separately to just remove the compiled binary.
-4. Execute `./cpp-on-rails` to start the sample server.
+2. Run `make` to build the executables. This automatically performs `make clean` before compiling.
+3. `make` automatically cleans before compiling, but you can run `make clean` separately to just remove the compiled binaries.
+4. Execute `./cpp-on-rails-dev` for a development build or `./cpp-on-rails-prod` for a production build to start the sample server. The application no longer opens a browser automatically, so navigate to the printed URL manually.
 
 ## Running tests
 


### PR DESCRIPTION
## Summary
- build development and production binaries
- make launching the browser optional via `OPEN_BROWSER`
- disable automatic browser launch
- update README usage instructions

## Testing
- `make test`
- `make`

------
https://chatgpt.com/codex/tasks/task_e_6844347a356c8324967939c221e8c0cb