### PR TITLE
Remove dev build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ cpp-on-rails
 *.o
 *.out
 *.exe
+cpp-on-rails-prod

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,12 @@
 CXX = g++
 CXXFLAGS = -std=c++17 -pthread
 SRC = application.cpp
-DEV_BIN = cpp-on-rails-dev
+BIN = cpp-on-rails
 PROD_BIN = cpp-on-rails-prod
 TEST_BIN = tests/run_tests
 TEST_SRC = tests/test_home_view.cpp
 
-all: clean $(DEV_BIN) $(PROD_BIN)
+all: clean $(BIN) $(PROD_BIN)
 
 test: $(TEST_BIN)
 	./$(TEST_BIN)
@@ -14,13 +14,13 @@ test: $(TEST_BIN)
 $(TEST_BIN): $(TEST_SRC)
 	$(CXX) $(CXXFLAGS) $^ -o $@
 
-$(DEV_BIN): $(SRC)
-	$(CXX) $(CXXFLAGS) -DDEVELOPMENT $(SRC) -o $(DEV_BIN)
-
 $(PROD_BIN): $(SRC)
 	$(CXX) $(CXXFLAGS) -DPRODUCTION $(SRC) -o $(PROD_BIN)
 
+$(BIN): $(SRC)
+	$(CXX) $(CXXFLAGS) $(SRC) -o $(BIN)
+
 clean:
-	rm -f $(DEV_BIN) $(PROD_BIN) $(TEST_BIN)
+	rm -f $(BIN) $(PROD_BIN) $(TEST_BIN)
 
 .PHONY: all clean test

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ C++ on Rails is not affiliated with or endorsed by the creators of Ruby on Rails
 1. Clone the repo
 2. Run `make` to build the executables. This automatically performs `make clean` before compiling.
 3. `make` automatically cleans before compiling, but you can run `make clean` separately to just remove the compiled binaries.
-4. Execute `./cpp-on-rails-dev` for a development build or `./cpp-on-rails-prod` for a production build to start the sample server. The application no longer opens a browser automatically, so navigate to the printed URL manually.
+4. Execute `./cpp-on-rails` for the default build or `./cpp-on-rails-prod` for a production build to start the sample server. The application no longer opens a browser automatically, so navigate to the printed URL manually.
 
 ## Running tests
 


### PR DESCRIPTION
## Summary
- remove the development binary from the build system
- default build outputs `cpp-on-rails`
- ignore the production binary
- update usage instructions for building and running

## Testing
- `make test`
- `make`
- `make clean`


------
https://chatgpt.com/codex/tasks/task_e_6844377690508324b9068878aa95159d