### PR TITLE
Re-enable browser auto launch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ $(PROD_BIN): $(SRC)
 	$(CXX) $(CXXFLAGS) -DPRODUCTION $(SRC) -o $(PROD_BIN)
 
 $(BIN): $(SRC)
-	$(CXX) $(CXXFLAGS) $(SRC) -o $(BIN)
+	$(CXX) $(CXXFLAGS) -DOPEN_BROWSER $(SRC) -o $(BIN)
 
 clean:
 	rm -f $(BIN) $(PROD_BIN) $(TEST_BIN)

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ C++ on Rails is not affiliated with or endorsed by the creators of Ruby on Rails
 1. Clone the repo
 2. Run `make` to build the executables. This automatically performs `make clean` before compiling.
 3. `make` automatically cleans before compiling, but you can run `make clean` separately to just remove the compiled binaries.
-4. Execute `./cpp-on-rails` for the default build or `./cpp-on-rails-prod` for a production build to start the sample server. The application no longer opens a browser automatically, so navigate to the printed URL manually.
+4. Execute `./cpp-on-rails` for the default build or `./cpp-on-rails-prod` for a production build to start the sample server. The default build now opens your browser automatically, while the production build does not.
 
 ## Running tests
 


### PR DESCRIPTION
## Summary
- build default executable with `OPEN_BROWSER` again
- document that the default build opens the browser automatically

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_684452ce5e1c8324b35e9e142d7745fb